### PR TITLE
Add ability to disable sending of queued mails.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add ability to disable sending of queued mails. Details see README.rst.
+  (`#14 <https://github.com/zopefoundation/Products.MailHost/issues/14>`_)
 
 
 4.3 (2019-03-08)

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,12 @@ An optional character set can be specified to automatically encode unicode
 input, and perform appropriate RFC 2822 header and body encoding for the
 specified character set. Full python email.Message.Message objects may be sent.
 
-Email can optionally be encoded using Base64 or Quoted-Printable encoding 
+Email can optionally be encoded using Base64 or Quoted-Printable encoding
 (though automatic body encoding will be applied if a character set is
 specified).
+
+Usage
+-----
 
 MailHost provides integration with the Zope transaction system and optional
 support for asynchronous mail delivery. Asynchronous mail delivery is
@@ -21,3 +24,10 @@ manage_restartQueueThread?action=start method through HTTP. There is currently
 no possibility to start the thread at Zope startup time.
 
 Supports TLS/SSL encryption (requires Python compiled with SSL support).
+
+Configuration
+-------------
+
+To force MailHost to only queue mails without sending them, activate queuing
+in the ZMI and set the environment variable ``MAILHOST_QUEUE_ONLY=1``.
+This could be helpful in a staging environment where mails should not be sent.

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,7 @@ parts =
 
 [versions]
 Products.MailHost =
+zope.sendmail =
 
 [interpreter]
 recipe = zc.recipe.egg

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'Zope >= 4.0b4',
         'zope.deferredimport',
         'zope.interface',
-        'zope.sendmail',
+        'zope.sendmail >= 5',
     ],
     extras_require={
         'genericsetup': ['Products.GenericSetup >= 2.0b1'],

--- a/src/Products/MailHost/MailHost.py
+++ b/src/Products/MailHost/MailHost.py
@@ -22,6 +22,7 @@ from email.utils import formataddr
 from email.utils import getaddresses
 from email.utils import parseaddr
 import logging
+import os
 from os.path import realpath
 import re
 import six
@@ -318,7 +319,8 @@ class MailBase(Implicit, Item, RoleManager):
         else:
             if self.smtp_queue:
                 # Start queue processor thread, if necessary
-                self._startQueueProcessorThread()
+                if not os.environ.get('MAILHOST_QUEUE_ONLY', False):
+                    self._startQueueProcessorThread()
                 delivery = QueuedMailDelivery(self.smtp_queue_directory)
             else:
                 delivery = DirectMailDelivery(self._makeMailer())


### PR DESCRIPTION
Fixes #14.

Tests on Python 3 are broken until zopefoundation/zope.sendmail#24 is merged and released.