### PR TITLE
Make Flake8 happy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.8 (unreleased)
 ----------------
 
+- Fix Flake8 issues.
+  (`#22 <https://github.com/zopefoundation/Products.MailHost/issues/22>`_)
+
 
 4.7 (2019-06-03)
 ----------------

--- a/src/Products/MailHost/MailHost.py
+++ b/src/Products/MailHost/MailHost.py
@@ -214,7 +214,7 @@ class MailBase(Implicit, Item, RoleManager):
 
     # This is here for backwards compatibility only. Possibly it could
     # be used to send messages at a scheduled future time, or via a mail queue?
-    security.declareProtected(use_mailhost_services,  # NOQA: flake8: D001
+    security.declareProtected(use_mailhost_services,  # noqa: D001
                               'scheduledSend')
     scheduledSend = send
 

--- a/src/Products/MailHost/__init__.py
+++ b/src/Products/MailHost/__init__.py
@@ -12,7 +12,7 @@
 ##############################################################################
 
 from Products.MailHost import MailHost
-from Products.MailHost import SendMailTag  # NOQA
+from Products.MailHost import SendMailTag  # noqa
 
 
 def initialize(context):

--- a/src/Products/MailHost/tests/testMailHost.py
+++ b/src/Products/MailHost/tests/testMailHost.py
@@ -33,7 +33,7 @@ from .dummy import FakeContent
 
 # Appease flake8
 if six.PY2:
-    unicode = unicode  # NOQA: flake8: F821
+    unicode = unicode  # noqa: F821
 else:
     unicode = str
 


### PR DESCRIPTION
There were some spots in the source code, which should be skipped by
Flake8; a noqa marker was already set, but Flake8 did not recognize the
syntax.

Syntax fixed according to:
http://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html

modified:   CHANGES.rst
modified:   src/Products/MailHost/MailHost.py
modified:   src/Products/MailHost/__init__.py
modified:   src/Products/MailHost/tests/testMailHost.py