### PR TITLE
Fix linting issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,8 @@ commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
     isort --check-only --diff --recursive {toxinidir}/src setup.py
-    - flake8 --format=html --doctests src tests setup.py
-    flake8 --doctests src tests setup.py
+    - flake8 --format=html --doctests src setup.py
+    flake8 --doctests src setup.py
 deps =
     isort
     flake8


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

modified:   tox.ini