### PR TITLE
Remove doc string from the MailHost ``send`` method to prevent publishing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.1 (unreleased)
 ----------------
 
+- Remove doc string from the MailHost ``send`` method to prevent publishing.
+
 - Add support for Python 3.12.
 
 

--- a/src/Products/MailHost/MailHost.py
+++ b/src/Products/MailHost/MailHost.py
@@ -209,11 +209,8 @@ class MailBase(Implicit, Item, RoleManager):
              immediate=False,
              charset=None,
              msg_type=None):
-        """send *messageText* modified by the other parameters.
-
-        *messageText* can either be an ``email.message.Message``
-        or a string.
-        """
+        # send *messageText* modified by the other parameters.
+        # *messageText* can be an ``email.message.Message`` or a string.
         msg, mto, mfrom = _mungeHeaders(messageText, mto, mfrom,
                                         subject, charset, msg_type,
                                         encode)


### PR DESCRIPTION
As discussed on the security list, this change reverts to the state before release 4.10 and prevents users who have the "User mailhost services" from sending arbitrary emails.