### PR TITLE
Use SMTP compatible line separators in generated messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 5.2 (unreleased)
 ----------------
 
+- Use SMTP compatible line separators in generated messages.
+
+- Remove doc string from the MailHost ``sendTemplate`` method
+  to prevent publishing.
+
+
 
 5.1 (2024-02-07)
 ----------------

--- a/src/Products/MailHost/MailHost.py
+++ b/src/Products/MailHost/MailHost.py
@@ -183,8 +183,8 @@ class MailBase(Implicit, Item, RoleManager):
                      immediate=False,
                      charset=None,
                      msg_type=None):
-        """Render a mail template, then send it...
-        """
+        # Render a mail template, then send it...
+        #
         mtemplate = getattr(self, messageTemplate)
         messageText = mtemplate(self, trueself.REQUEST)
         trueself.send(messageText, mto=mto, mfrom=mfrom,
@@ -224,8 +224,8 @@ class MailBase(Implicit, Item, RoleManager):
 
     @security.protected(use_mailhost_services)
     def simple_send(self, mto, mfrom, subject, body, immediate=False):
-        body = f'From: {mfrom}\nTo: {mto}\nSubject: {subject}\n\n{body}'
-        self._send(mfrom, mto, body, immediate)
+        msg = f'From: {mfrom}\nTo: {mto}\nSubject: {subject}\n\n{body}'
+        self.send(msg, immediate=immediate)
 
     def _makeMailer(self):
         """ Create a SMTPMailer """


### PR DESCRIPTION
This PR ensures that `MailHost` uses SMTP compatible line separators in generated messages. This has already been the case for its main method `send`, the PR makes sure, it is the case for its `simple_send` as well.

The PR also converts the docstring of `sendTemplate` into a comment to explicitely prevent publication. As @dataflake has pointed out this should not be strictly necessary for security reasons (because a Web request has difficulties to adhere to the signature), it is good to indicate "method not meant to be published".